### PR TITLE
Configure walking limit and dynamic search window

### DIFF
--- a/router-config.json
+++ b/router-config.json
@@ -19,6 +19,18 @@
       "parkAndRideDurationRatio": 0.6,
       "minBikeParkingDistance": 500,
       "transitGeneralizedCostLimit": "900 + 2.0 x"
+    },
+    "maxAccessEgressDurationSecondsForMode": {
+      "WALK": 1200 // 20 minutes
+    },
+    "maxJourneyDuration": "12h"
+  },
+  "transit": {
+    "dynamicSearchWindow" : {
+      "minTransitTimeCoefficient" : 0.5,
+      "minWaitTimeCoefficient" : 0.5,
+      "minWinTimeMinutes" : 60,
+      "maxWinTimeMinutes" : 300
     }
   },
   "flex": {


### PR DESCRIPTION
This PR improves the following:

- limits access/egress walking to 20 minutes in order to improve performance
- set a max journey duration in order to improve performance
- configure the maximum dynamic search window in order to still find routes in areas with low-frequency coverage