### PR TITLE
Sidestep the carpool URL from Github Secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ ENV GTFS_URL=$gtfs_url
 
 # GTFS Daten von fahrgemeinschaft mifaz
 # URL ist hinterlegt in GITHUB Secrets: GTFS_CARPOOL_URL
-RUN --mount=type=secret,id=GTFS_CARPOOL_URL export GTFS_CARPOOL_URL=$(cat /run/secrets/GTFS_CARPOOL_URL) && curl -LJO $GTFS_CARPOOL_URL
+#RUN --mount=type=secret,id=GTFS_CARPOOL_URL export GTFS_CARPOOL_URL=$(cat /run/secrets/GTFS_CARPOOL_URL) && curl -LJO $GTFS_CARPOOL_URL
+ARG gtfs_carpool_feed_url=https://amarillo.bbnavi.de/gtfs/amarillo.bb.gtfs.zip
+ENV GTFS_CARPOOL_FEED_URL=$gtfs_carpool_feed_url
 
 # GTFS Daten von FlexFeed derhuerst
 ARG gtfs_flexfeed_url=https://opendata.bbnavi.de/vbb-gtfs-flex/gtfs-flex.zip
@@ -42,8 +44,9 @@ ADD build-config.json /opt/opentripplanner/build/
 ADD otp-config.json /opt/opentripplanner/build/
 ADD $OSM_PBF_URL /opt/opentripplanner/build/
 ADD $GTFS_URL /opt/opentripplanner/build/gtfs.zip
-RUN cp mfdz.bb.gtfs.zip /opt/opentripplanner/build/gtfs-carpool.zip
+#RUN cp mfdz.bb.gtfs.zip /opt/opentripplanner/build/gtfs-carpool.zip
 ADD $GTFS_FLEXFEED_URL /opt/opentripplanner/build/
+ADD $GTFS_CARPOOL_FEED_URL /opt/opentripplanner/build/gtfs-carpool.gtfs.zip
 ADD dgm/* /opt/opentripplanner/build/
 
 # print version


### PR DESCRIPTION
We don't have access to the Github Secrets and want to test the Amarillo service.