### PR TITLE
Use newest OTP version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-ARG OTP_TAG=2022-04-27-16_55
+ARG OTP_TAG=2022-04-29-11_11
 ARG OTP_IMAGE=mfdz/opentripplanner
 
 FROM $OTP_IMAGE:$OTP_TAG AS otp


### PR DESCRIPTION
This fixes the bug where flex trips consisting of a single location group are removed from the API.