### PR TITLE
Set memory limit for OTP

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,3 +13,5 @@ services:
         traefik.frontend.passHostHeader: "true"
         traefik.frontend.rule: Host:staging.api.bbnavi.de
         traefik.port: '8080'
+    environment:
+      MEMORY: "24g"


### PR DESCRIPTION
Since we having problems with OTP being killed (presumably by the OOM killer) I'm limiting its memory.